### PR TITLE
feat(ts): configurable import extension via `import_ext`

### DIFF
--- a/pkgs/crate-genotype-backend/src/backend/system.rs
+++ b/pkgs/crate-genotype-backend/src/backend/system.rs
@@ -561,9 +561,7 @@ mod tests {
               "formatters": [],
               "mode": types,
               "prefer": interface,
-              "tsconfig": TsConfigLangTsconfig(
-                allowImportingTsExtensions: false,
-              ),
+              "import_ext": js,
             },
             py: {
               "module": PyModuleName("module"),
@@ -807,9 +805,7 @@ mod tests {
               "formatters": [],
               "mode": types,
               "prefer": interface,
-              "tsconfig": TsConfigLangTsconfig(
-                allowImportingTsExtensions: false,
-              ),
+              "import_ext": js,
             },
             py: {
               "module": PyModuleName("module"),
@@ -967,9 +963,7 @@ mod tests {
               "formatters": [],
               "mode": types,
               "prefer": interface,
-              "tsconfig": TsConfigLangTsconfig(
-                allowImportingTsExtensions: false,
-              ),
+              "import_ext": js,
             },
             py: {
               "module": PyModuleName("module"),

--- a/pkgs/crate-genotype-lang-ts-config/src/lang.rs
+++ b/pkgs/crate-genotype-lang-ts-config/src/lang.rs
@@ -6,7 +6,8 @@ pub struct TsConfigLang {
     pub mode: TsMode,
     #[serde(default)]
     pub prefer: TsPrefer,
-    pub tsconfig: TsConfigLangTsconfig,
+    #[serde(default, rename = "import_ext")]
+    pub ext: TsImportExt,
 }
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Clone, Default)]
@@ -25,29 +26,32 @@ pub enum TsPrefer {
     Alias,
 }
 
-#[derive(Default, Debug, Serialize, Deserialize, PartialEq, Clone)]
-pub struct TsConfigLangTsconfig {
-    #[serde(rename = "allowImportingTsExtensions")]
-    pub allow_importing_ts_extensions: bool,
+#[derive(Debug, Serialize, Deserialize, PartialEq, Clone, Copy, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum TsImportExt {
+    #[default]
+    Js,
+    Ts,
+    None,
 }
 
 impl TsConfigLang {
     pub fn format_module_path(&self, path: &GtpPkgSrcDirRelativePath) -> String {
-        let mut path = path.as_str().to_string();
-        if !self.tsconfig.allow_importing_ts_extensions && path.ends_with(".ts") {
-            let len = path.len();
-            path.replace_range(len - 2..len, "js");
+        let path = path.as_str();
+        let stem = path.strip_suffix(".ts").unwrap_or(path);
+        match self.ext {
+            TsImportExt::Js => format!("{stem}.js"),
+            TsImportExt::Ts => format!("{stem}.ts"),
+            TsImportExt::None => stem.to_string(),
         }
-        path
     }
 
     pub fn format_import_path(&self, path: &str) -> String {
-        let ext = if self.tsconfig.allow_importing_ts_extensions {
-            "ts"
-        } else {
-            "js"
-        };
-        format!("{path}.{ext}")
+        match self.ext {
+            TsImportExt::Js => format!("{path}.js"),
+            TsImportExt::Ts => format!("{path}.ts"),
+            TsImportExt::None => path.to_string(),
+        }
     }
 }
 
@@ -62,13 +66,15 @@ mod tests {
     }
 
     #[test]
+    fn test_default_import_ext_js() {
+        assert_eq!(TsConfigLang::default().ext, TsImportExt::Js);
+    }
+
+    #[test]
     fn test_format_module_path() {
         let config = TsConfigLang {
-            mode: Default::default(),
-            prefer: Default::default(),
-            tsconfig: TsConfigLangTsconfig {
-                allow_importing_ts_extensions: true,
-            },
+            ext: TsImportExt::Ts,
+            ..Default::default()
         };
         assert_eq!(
             config.format_module_path(&"path/to/module.ts".into()),
@@ -76,36 +82,42 @@ mod tests {
         );
 
         let config = TsConfigLang {
-            mode: Default::default(),
-            prefer: Default::default(),
-            tsconfig: TsConfigLangTsconfig {
-                allow_importing_ts_extensions: false,
-            },
+            ext: TsImportExt::Js,
+            ..Default::default()
         };
         assert_eq!(
             config.format_module_path(&"path/to/module.ts".into()),
             "path/to/module.js"
+        );
+
+        let config = TsConfigLang {
+            ext: TsImportExt::None,
+            ..Default::default()
+        };
+        assert_eq!(
+            config.format_module_path(&"path/to/module.ts".into()),
+            "path/to/module"
         );
     }
 
     #[test]
     fn test_format_import_path() {
         let config = TsConfigLang {
-            mode: Default::default(),
-            prefer: Default::default(),
-            tsconfig: TsConfigLangTsconfig {
-                allow_importing_ts_extensions: true,
-            },
+            ext: TsImportExt::Ts,
+            ..Default::default()
         };
         assert_eq!(config.format_import_path("foo"), "foo.ts");
 
         let config = TsConfigLang {
-            mode: Default::default(),
-            prefer: Default::default(),
-            tsconfig: TsConfigLangTsconfig {
-                allow_importing_ts_extensions: false,
-            },
+            ext: TsImportExt::Js,
+            ..Default::default()
         };
         assert_eq!(config.format_import_path("foo"), "foo.js");
+
+        let config = TsConfigLang {
+            ext: TsImportExt::None,
+            ..Default::default()
+        };
+        assert_eq!(config.format_import_path("foo"), "foo");
     }
 }

--- a/pkgs/crate-genotype-lang-ts-project/src/compiler.rs
+++ b/pkgs/crate-genotype-lang-ts-project/src/compiler.rs
@@ -689,6 +689,68 @@ mod tests {
     }
 
     #[test]
+    fn test_render_import_ext_ts() {
+        let backend = GtbSystem::new(&"./examples/basic".into()).unwrap();
+        let mut project = block_on(backend.create_project_and_load_all_modules(None)).unwrap();
+        project.config_mut().ts.lang.ext = TsImportExt::Ts;
+
+        let dist = compile(&project);
+
+        let book_file = get_dist_file(&dist, "src/book.ts");
+        assert_snapshot!(
+            book_file.source_code,
+            @r#"
+        import { Author } from "./author.ts";
+
+        export interface Book {
+          title: string;
+          author: Author;
+        }
+        "#
+        );
+
+        let index_file = get_dist_file(&dist, "src/index.ts");
+        assert_snapshot!(
+            index_file.source_code,
+            @r#"
+        export * from "./author.ts";
+        export * from "./book.ts";
+        "#
+        );
+    }
+
+    #[test]
+    fn test_render_import_ext_none() {
+        let backend = GtbSystem::new(&"./examples/basic".into()).unwrap();
+        let mut project = block_on(backend.create_project_and_load_all_modules(None)).unwrap();
+        project.config_mut().ts.lang.ext = TsImportExt::None;
+
+        let dist = compile(&project);
+
+        let book_file = get_dist_file(&dist, "src/book.ts");
+        assert_snapshot!(
+            book_file.source_code,
+            @r#"
+        import { Author } from "./author";
+
+        export interface Book {
+          title: string;
+          author: Author;
+        }
+        "#
+        );
+
+        let index_file = get_dist_file(&dist, "src/index.ts");
+        assert_snapshot!(
+            index_file.source_code,
+            @r#"
+        export * from "./author";
+        export * from "./book";
+        "#
+        );
+    }
+
+    #[test]
     fn test_render_without_package_global() {
         let backend = GtbSystem::new(&"./examples/basic".into()).unwrap();
         let mut project = block_on(backend.create_project_and_load_all_modules(None)).unwrap();

--- a/pkgs/crate-genotype-lang-ts-tree/src/path/render.rs
+++ b/pkgs/crate-genotype-lang-ts-tree/src/path/render.rs
@@ -31,9 +31,7 @@ mod tests {
     fn render_ts_ext() {
         let mut ctx = TsRenderContext {
             config: &TsConfigLang {
-                tsconfig: TsConfigLangTsconfig {
-                    allow_importing_ts_extensions: true,
-                },
+                ext: TsImportExt::Ts,
                 ..Default::default()
             },
             ..Default::default()
@@ -41,6 +39,21 @@ mod tests {
         assert_snapshot!(
             render_node_with(Tst::path("./path/to/module"), &mut ctx),
             @"./path/to/module.ts"
+        );
+    }
+
+    #[test]
+    fn render_none_ext() {
+        let mut ctx = TsRenderContext {
+            config: &TsConfigLang {
+                ext: TsImportExt::None,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        assert_snapshot!(
+            render_node_with(Tst::path("./path/to/module"), &mut ctx),
+            @"./path/to/module"
         );
     }
 

--- a/pkgs/crate-genotype-project/src/config/mod.rs
+++ b/pkgs/crate-genotype-project/src/config/mod.rs
@@ -184,7 +184,7 @@ enabled = true
 
     #[test]
     fn test_parse_target() {
-        let config = toml::from_str::<GtpConfig>(
+        let config = GtpConfig::from_toml_str(
             r#"package = false
 
 [ts]
@@ -199,6 +199,42 @@ import_ext = "ts"
         assert_eq!(config.ts.common.package, Some(true));
         assert_eq!(config.py.common.package, None);
         assert_eq!(config.ts.lang.ext, TsImportExt::Ts);
+    }
+
+    #[test]
+    fn test_parse_ts_import_ext() {
+        assert_eq!(
+            GtpConfig::from_toml_str("[ts]\nimport_ext = \"js\"\n")
+                .unwrap()
+                .ts
+                .lang
+                .ext,
+            TsImportExt::Js
+        );
+        assert_eq!(
+            GtpConfig::from_toml_str("[ts]\nimport_ext = \"ts\"\n")
+                .unwrap()
+                .ts
+                .lang
+                .ext,
+            TsImportExt::Ts
+        );
+        assert_eq!(
+            GtpConfig::from_toml_str("[ts]\nimport_ext = \"none\"\n")
+                .unwrap()
+                .ts
+                .lang
+                .ext,
+            TsImportExt::None
+        );
+        assert_eq!(
+            GtpConfig::from_toml_str("[ts]\nenabled = true\n")
+                .unwrap()
+                .ts
+                .lang
+                .ext,
+            TsImportExt::Js
+        );
     }
 
     #[test]

--- a/pkgs/crate-genotype-project/src/config/mod.rs
+++ b/pkgs/crate-genotype-project/src/config/mod.rs
@@ -190,7 +190,7 @@ enabled = true
 [ts]
 enabled = true
 package = true
-tsconfig = { allowImportingTsExtensions = false }
+import_ext = "ts"
 "#,
         )
         .unwrap();
@@ -198,6 +198,7 @@ tsconfig = { allowImportingTsExtensions = false }
         assert!(!config.package);
         assert_eq!(config.ts.common.package, Some(true));
         assert_eq!(config.py.common.package, None);
+        assert_eq!(config.ts.lang.ext, TsImportExt::Ts);
     }
 
     #[test]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #100

Makes TypeScript import/export path extensions configurable:

```toml
[ts]
enabled = true
import_ext = "ts" # "js" | "ts" | "none"
```

- Adds `TsImportExt` (`Js` | `Ts` | `None`) on `TsConfigLang` as `ext`, serialized as `import_ext`
- Defaults to `js` (previous behavior)
- Replaces `tsconfig.allowImportingTsExtensions` with this option
- Applies to both module imports and barrel `export * from` paths
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7d94a3d6-acd1-487e-943c-502ab7e8f13a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7d94a3d6-acd1-487e-943c-502ab7e8f13a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

