### PR TITLE
TS import/export file extension `ext` config, use `tsconfig` config to generate `tsconfig.json`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1244,6 +1244,7 @@ dependencies = [
  "pretty_assertions",
  "relative-path",
  "serde",
+ "toml 0.8.22",
 ]
 
 [[package]]
@@ -1269,6 +1270,7 @@ dependencies = [
  "pretty_assertions",
  "semver",
  "serde",
+ "serde_json",
  "toml 0.8.22",
  "toml_edit",
 ]

--- a/pkgs/crate-genotype-backend/src/backend/system.rs
+++ b/pkgs/crate-genotype-backend/src/backend/system.rs
@@ -561,9 +561,8 @@ mod tests {
               "formatters": [],
               "mode": types,
               "prefer": interface,
-              "tsconfig": TsConfigLangTsconfig(
-                allowImportingTsExtensions: false,
-              ),
+              "ext": js,
+              "tsconfig": None,
             },
             py: {
               "module": PyModuleName("module"),
@@ -807,9 +806,8 @@ mod tests {
               "formatters": [],
               "mode": types,
               "prefer": interface,
-              "tsconfig": TsConfigLangTsconfig(
-                allowImportingTsExtensions: false,
-              ),
+              "ext": js,
+              "tsconfig": None,
             },
             py: {
               "module": PyModuleName("module"),
@@ -967,9 +965,8 @@ mod tests {
               "formatters": [],
               "mode": types,
               "prefer": interface,
-              "tsconfig": TsConfigLangTsconfig(
-                allowImportingTsExtensions: false,
-              ),
+              "ext": js,
+              "tsconfig": None,
             },
             py: {
               "module": PyModuleName("module"),

--- a/pkgs/crate-genotype-lang-ts-config/Cargo.toml
+++ b/pkgs/crate-genotype-lang-ts-config/Cargo.toml
@@ -12,6 +12,7 @@ genotype_core = { version = "0.16.2", path = "../crate-genotype-core" }
 genotype_project_core = { version = "0.16.2", path = "../crate-genotype-project-core" }
 serde = { version = "1.0.228", features = ["derive"] }
 relative-path = { version = "1.9.3", features = ["serde"] }
+toml = { version = "0.8.19" }
 
 [dev-dependencies]
 pretty_assertions = "1.4.1"

--- a/pkgs/crate-genotype-lang-ts-config/src/lang.rs
+++ b/pkgs/crate-genotype-lang-ts-config/src/lang.rs
@@ -6,7 +6,10 @@ pub struct TsConfigLang {
     pub mode: TsMode,
     #[serde(default)]
     pub prefer: TsPrefer,
-    pub tsconfig: TsConfigLangTsconfig,
+    #[serde(default)]
+    pub ext: TsImportExt,
+    #[serde(default)]
+    pub tsconfig: Option<TsConfigLangTsconfig>,
 }
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Clone, Default)]
@@ -25,29 +28,36 @@ pub enum TsPrefer {
     Alias,
 }
 
-#[derive(Default, Debug, Serialize, Deserialize, PartialEq, Clone)]
-pub struct TsConfigLangTsconfig {
-    #[serde(rename = "allowImportingTsExtensions")]
-    pub allow_importing_ts_extensions: bool,
+#[derive(Debug, Serialize, Deserialize, PartialEq, Clone, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum TsImportExt {
+    #[default]
+    Js,
+    Ts,
+    None,
 }
+
+pub type TsConfigLangTsconfig = toml::Table;
 
 impl TsConfigLang {
     pub fn format_module_path(&self, path: &GtpPkgSrcDirRelativePath) -> String {
-        let mut path = path.as_str().to_string();
-        if !self.tsconfig.allow_importing_ts_extensions && path.ends_with(".ts") {
-            let len = path.len();
-            path.replace_range(len - 2..len, "js");
+        let path = path.as_str();
+        let Some(path) = path.strip_suffix(".ts") else {
+            return path.to_string();
+        };
+        match self.ext {
+            TsImportExt::Js => format!("{path}.js"),
+            TsImportExt::Ts => format!("{path}.ts"),
+            TsImportExt::None => path.to_string(),
         }
-        path
     }
 
     pub fn format_import_path(&self, path: &str) -> String {
-        let ext = if self.tsconfig.allow_importing_ts_extensions {
-            "ts"
-        } else {
-            "js"
-        };
-        format!("{path}.{ext}")
+        match self.ext {
+            TsImportExt::Js => format!("{path}.js"),
+            TsImportExt::Ts => format!("{path}.ts"),
+            TsImportExt::None => path.to_string(),
+        }
     }
 }
 
@@ -62,13 +72,15 @@ mod tests {
     }
 
     #[test]
+    fn test_default_tsconfig() {
+        assert_eq!(TsConfigLang::default().tsconfig, None);
+    }
+
+    #[test]
     fn test_format_module_path() {
         let config = TsConfigLang {
-            mode: Default::default(),
-            prefer: Default::default(),
-            tsconfig: TsConfigLangTsconfig {
-                allow_importing_ts_extensions: true,
-            },
+            ext: TsImportExt::Ts,
+            ..Default::default()
         };
         assert_eq!(
             config.format_module_path(&"path/to/module.ts".into()),
@@ -76,36 +88,42 @@ mod tests {
         );
 
         let config = TsConfigLang {
-            mode: Default::default(),
-            prefer: Default::default(),
-            tsconfig: TsConfigLangTsconfig {
-                allow_importing_ts_extensions: false,
-            },
+            ext: TsImportExt::Js,
+            ..Default::default()
         };
         assert_eq!(
             config.format_module_path(&"path/to/module.ts".into()),
             "path/to/module.js"
+        );
+
+        let config = TsConfigLang {
+            ext: TsImportExt::None,
+            ..Default::default()
+        };
+        assert_eq!(
+            config.format_module_path(&"path/to/module.ts".into()),
+            "path/to/module"
         );
     }
 
     #[test]
     fn test_format_import_path() {
         let config = TsConfigLang {
-            mode: Default::default(),
-            prefer: Default::default(),
-            tsconfig: TsConfigLangTsconfig {
-                allow_importing_ts_extensions: true,
-            },
+            ext: TsImportExt::Ts,
+            ..Default::default()
         };
         assert_eq!(config.format_import_path("foo"), "foo.ts");
 
         let config = TsConfigLang {
-            mode: Default::default(),
-            prefer: Default::default(),
-            tsconfig: TsConfigLangTsconfig {
-                allow_importing_ts_extensions: false,
-            },
+            ext: TsImportExt::Js,
+            ..Default::default()
         };
         assert_eq!(config.format_import_path("foo"), "foo.js");
+
+        let config = TsConfigLang {
+            ext: TsImportExt::None,
+            ..Default::default()
+        };
+        assert_eq!(config.format_import_path("foo"), "foo");
     }
 }

--- a/pkgs/crate-genotype-lang-ts-project/Cargo.toml
+++ b/pkgs/crate-genotype-lang-ts-project/Cargo.toml
@@ -19,6 +19,7 @@ genotype_lang_ts_tree = { version = "0.16.2", path = "../crate-genotype-lang-ts-
 genotype_lang_ts_config = { version = "0.16.2", path = "../crate-genotype-lang-ts-config" }
 toml_edit = { version = "0.22.26", features = ["serde"] }
 serde = { version = "1.0.228", features = ["derive"] }
+serde_json = "1.0.145"
 miette = { version = "7.6.0", features = ["serde"] }
 semver = { version = "1.0.27", features = ["serde"] }
 pluralizer = "0.5.0"

--- a/pkgs/crate-genotype-lang-ts-project/src/compiler.rs
+++ b/pkgs/crate-genotype-lang-ts-project/src/compiler.rs
@@ -35,8 +35,15 @@ impl<'project> GtlCompiler<'project> for TsCompiler<'project> {
         &self,
         project: &GtlProject<'_, '_, TsProjectModule>,
     ) -> Option<GtlGenerations<TsProjectModule>> {
-        let (barrel_file, diagnostics) = self.generate_barrel_file(&project.modules);
-        Some((vec![barrel_file], Some(diagnostics)))
+        let (barrel_file, mut diagnostics) = self.generate_barrel_file(&project.modules);
+        let mut files = vec![barrel_file];
+        if self.config.package_enabled()
+            && let Some(tsconfig) = &self.lang_config().lang.tsconfig
+            && let Some(tsconfig_file) = self.generate_tsconfig_file(tsconfig, &mut diagnostics)
+        {
+            files.push(tsconfig_file);
+        }
+        Some((files, Some(diagnostics)))
     }
 
     fn gitignore_source_code(&self) -> Option<String> {
@@ -45,6 +52,24 @@ impl<'project> GtlCompiler<'project> for TsCompiler<'project> {
 }
 
 impl TsCompiler<'_> {
+    fn generate_tsconfig_file(
+        &self,
+        tsconfig: &TsConfigLangTsconfig,
+        diagnostics: &mut Vec<GtDiagnostic>,
+    ) -> Option<GtlGeneration<TsProjectModule>> {
+        let path = self.config.pkg_file_path(&"tsconfig.json".into());
+        match serde_json::to_string_pretty(tsconfig) {
+            Ok(source_code) => Some(GtlProjectFileExtraGenerated { path, source_code }.into()),
+
+            Err(err) => {
+                diagnostics.push(GtDiagnostic::error(format!(
+                    "Failed to generate `{path}`: {err}"
+                )));
+                None
+            }
+        }
+    }
+
     fn generate_barrel_file(
         &self,
         modules: &IndexMap<GtpModulePath, GtlProjectModuleState<TsProjectModule>>,
@@ -516,6 +541,51 @@ mod tests {
           diagnostics: [],
         )
         "#
+        );
+    }
+
+    #[test]
+    fn test_render_ext_and_tsconfig() {
+        let backend = GtbSystem::new(&"./examples/basic".into()).unwrap();
+        let mut project = block_on(backend.create_project_and_load_all_modules(None)).unwrap();
+        project.config_mut().ts.lang.ext = TsImportExt::Ts;
+        project.config_mut().ts.lang.tsconfig = Some(
+            toml::from_str(
+                r#"include = ["src/**/*.ts"]
+    "#,
+            )
+            .unwrap(),
+        );
+
+        let dist = compile(&project);
+
+        assert_snapshot!(
+          get_dist_file(&dist, "src/book.ts").source_code,
+          @r#"
+      import { Author } from "./author.ts";
+
+      export interface Book {
+        title: string;
+        author: Author;
+      }
+      "#
+        );
+        assert_snapshot!(
+          get_dist_file(&dist, "src/index.ts").source_code,
+          @r#"
+      export * from "./author.ts";
+      export * from "./book.ts";
+      "#
+        );
+        assert_snapshot!(
+          get_dist_file(&dist, "tsconfig.json").source_code,
+          @r#"
+      {
+        "include": [
+          "src/**/*.ts"
+        ]
+      }
+      "#
         );
     }
 

--- a/pkgs/crate-genotype-lang-ts-tree/src/path/render.rs
+++ b/pkgs/crate-genotype-lang-ts-tree/src/path/render.rs
@@ -31,9 +31,7 @@ mod tests {
     fn render_ts_ext() {
         let mut ctx = TsRenderContext {
             config: &TsConfigLang {
-                tsconfig: TsConfigLangTsconfig {
-                    allow_importing_ts_extensions: true,
-                },
+                ext: TsImportExt::Ts,
                 ..Default::default()
             },
             ..Default::default()
@@ -41,6 +39,21 @@ mod tests {
         assert_snapshot!(
             render_node_with(Tst::path("./path/to/module"), &mut ctx),
             @"./path/to/module.ts"
+        );
+    }
+
+    #[test]
+    fn render_no_ext() {
+        let mut ctx = TsRenderContext {
+            config: &TsConfigLang {
+                ext: TsImportExt::None,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        assert_snapshot!(
+            render_node_with(Tst::path("./path/to/module"), &mut ctx),
+            @"./path/to/module"
         );
     }
 

--- a/pkgs/crate-genotype-project/src/config/mod.rs
+++ b/pkgs/crate-genotype-project/src/config/mod.rs
@@ -190,14 +190,35 @@ enabled = true
 [ts]
 enabled = true
 package = true
-tsconfig = { allowImportingTsExtensions = false }
+ext = "ts"
 "#,
         )
         .unwrap();
 
         assert!(!config.package);
         assert_eq!(config.ts.common.package, Some(true));
+        assert_eq!(config.ts.lang.ext, TsImportExt::Ts);
         assert_eq!(config.py.common.package, None);
+    }
+
+    #[test]
+    fn test_parse_ts_ext() {
+        let config = GtpConfig::from_toml_str(
+            r#"[ts]
+ext = "none"
+tsconfig = { include = ["src/**/*.ts"] }
+"#,
+        )
+        .unwrap();
+
+        assert_eq!(config.ts.lang.ext, TsImportExt::None);
+        let tsconfig = config.ts.lang.tsconfig.as_ref().unwrap();
+        assert_eq!(
+            tsconfig.get("include"),
+            Some(&toml::Value::Array(vec![toml::Value::String(
+                "src/**/*.ts".into()
+            )]))
+        );
     }
 
     #[test]


### PR DESCRIPTION
See #100 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable TypeScript import extensions: JavaScript, TypeScript, or no extension.
  - Added support for optional custom TypeScript configuration through TOML settings.
  - Packaging can now generate a formatted `tsconfig.json` file when configured.
  - Improved TypeScript path rendering to follow the selected extension mode.

- **Tests**
  - Expanded coverage for extension modes, custom TypeScript configuration, and generated project files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->