### PR TITLE
Add warning comment to generated target files (closes #129)

### DIFF
--- a/pkgs/crate-genotype-backend/src/backend/system.rs
+++ b/pkgs/crate-genotype-backend/src/backend/system.rs
@@ -552,6 +552,7 @@ mod tests {
             src: "src",
             entry: "**/*.type",
             formatters: [],
+            warning_comment: true,
             ts: {
               "enabled": false,
               "dist": None,
@@ -797,6 +798,7 @@ mod tests {
             src: "src",
             entry: "**/*.type",
             formatters: [],
+            warning_comment: true,
             ts: {
               "enabled": false,
               "dist": None,
@@ -956,6 +958,7 @@ mod tests {
             src: "src",
             entry: "**/*.type",
             formatters: [],
+            warning_comment: true,
             ts: {
               "enabled": false,
               "dist": None,

--- a/pkgs/crate-genotype-lang-core-project/src/compiler/mod.rs
+++ b/pkgs/crate-genotype-lang-core-project/src/compiler/mod.rs
@@ -41,7 +41,7 @@ where
         let mut lang_project = GtlProject::<Self::ProjectModule>::new(self.config());
         lang_project.convert(self.project().modules());
         lang_project.resolve()?;
-        lang_project.render();
+        lang_project.render()?;
 
         diagnostics.extend(generate_module_diagnostics(&lang_project.modules));
 

--- a/pkgs/crate-genotype-lang-core-project/src/config/mod.rs
+++ b/pkgs/crate-genotype-lang-core-project/src/config/mod.rs
@@ -42,4 +42,8 @@ impl<'project, LangConfig: GtpLangConfig> GtlConfig<'project, LangConfig> {
     pub fn project_version(&self) -> Option<&'project Version> {
         self.project.config().version.as_ref()
     }
+
+    pub fn warning_comment(&self) -> bool {
+        self.project.config().warning_comment
+    }
 }

--- a/pkgs/crate-genotype-lang-core-project/src/error.rs
+++ b/pkgs/crate-genotype-lang-core-project/src/error.rs
@@ -5,13 +5,19 @@ pub enum GtlProjectError {
     #[error("Failed to resolve project")]
     Resolve { error: Box<dyn GtlError> },
 
-    #[error("Failed to generate file `{path}`")]
-    GenerateFile {
-        path: GtpCwdRelativePath,
+    #[error("Failed to generate target file `{path}`")]
+    GenerateTargetFile {
+        path: GtpTargetFilePath,
         #[source]
         #[diagnostic_source]
         error: Box<dyn GtlError>,
     },
+}
+
+impl GtlError for GtlProjectError {
+    fn clone_box(&self) -> Box<dyn GtlError> {
+        Box::new(self.clone())
+    }
 }
 
 impl GtlProjectError {

--- a/pkgs/crate-genotype-lang-core-project/src/project/renderer.rs
+++ b/pkgs/crate-genotype-lang-core-project/src/project/renderer.rs
@@ -3,7 +3,7 @@ use crate::prelude::internal::*;
 impl<'project, 'config, ProjectModule: GtlProjectModule>
     GtlProject<'project, 'config, ProjectModule>
 {
-    pub fn render(&mut self) {
+    pub fn render(&mut self) -> Result<(), GtlProjectError> {
         self.modules = mem::take(&mut self.modules)
             .into_iter()
             .map(|(module_path, module_state)| {
@@ -23,6 +23,13 @@ impl<'project, 'config, ProjectModule: GtlProjectModule>
                         let source_code = inner.resolved_module.render(self.config.lang_config());
                         match source_code {
                             Ok(source_code) => {
+                                let source_code = if self.config.warning_comment() {
+                                    let warning =
+                                        self.render_generated_warning(&inner.converted)?;
+                                    format!("{warning}\n\n{source_code}")
+                                } else {
+                                    source_code
+                                };
                                 GtlProjectModuleState::Rendered(inner.to_rendered(source_code))
                             }
 
@@ -33,8 +40,29 @@ impl<'project, 'config, ProjectModule: GtlProjectModule>
                         }
                     }
                 };
-                (module_path, new_state)
+                Ok((module_path, new_state))
             })
-            .collect();
+            .collect::<Result<_, GtlProjectError>>()?;
+        Ok(())
+    }
+
+    fn render_generated_warning(
+        &self,
+        converted: &GtlProjectModuleConverted<ProjectModule>,
+    ) -> Result<String, GtlProjectError> {
+        let target_dir = converted
+            .target_path
+            .relative_path()
+            .parent()
+            .ok_or_else(|| GtlProjectError::GenerateTargetFile {
+                path: converted.target_path.clone(),
+                error: "Failed to resolve the target file parent directory".into(),
+            })?;
+
+        let source_path = target_dir.relative(converted.source_path.relative_path());
+        let content = format!("Do not edit manually! Code generated from {source_path}",);
+        self.config.project_version();
+        let comment = self.config.lang_config().comment_line(&content);
+        Ok(comment)
     }
 }

--- a/pkgs/crate-genotype-lang-core-tree/src/error/message.rs
+++ b/pkgs/crate-genotype-lang-core-tree/src/error/message.rs
@@ -1,0 +1,24 @@
+use std::fmt::Display;
+
+use crate::prelude::internal::*;
+
+#[derive(Debug, Clone, PartialEq, Error, Diagnostic, Serialize)]
+pub struct GtlErrorMessage(pub String);
+
+impl Display for GtlErrorMessage {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl GtlError for GtlErrorMessage {
+    fn clone_box(&self) -> Box<dyn GtlError> {
+        Box::new(self.clone())
+    }
+}
+
+impl<Str: AsRef<str>> From<Str> for Box<dyn GtlError> {
+    fn from(message: Str) -> Self {
+        Box::new(GtlErrorMessage(message.as_ref().to_string()))
+    }
+}

--- a/pkgs/crate-genotype-lang-core-tree/src/error/mod.rs
+++ b/pkgs/crate-genotype-lang-core-tree/src/error/mod.rs
@@ -1,5 +1,8 @@
 use crate::prelude::internal::*;
 
+mod message;
+pub use message::*;
+
 pub trait GtlError: StdError + Diagnostic + 'static {
     fn clone_box(&self) -> Box<dyn GtlError>;
 

--- a/pkgs/crate-genotype-lang-core-tree/src/prelude.rs
+++ b/pkgs/crate-genotype-lang-core-tree/src/prelude.rs
@@ -9,4 +9,5 @@ pub(crate) mod internal {
     pub use std::error::Error as StdError;
     pub use std::fmt::Debug;
     pub use std::hash::Hash;
+    pub use thiserror::Error;
 }

--- a/pkgs/crate-genotype-lang-py-config/src/config.rs
+++ b/pkgs/crate-genotype-lang-py-config/src/config.rs
@@ -26,4 +26,8 @@ impl GtpLangConfig for PyConfig {
     fn default_pkg_dir_path(&self) -> GtpDistDirRelativePkgDirPath {
         "py".into()
     }
+
+    fn comment_prefix(&self) -> &'static str {
+        "#"
+    }
 }

--- a/pkgs/crate-genotype-lang-py-project/src/compiler.rs
+++ b/pkgs/crate-genotype-lang-py-project/src/compiler.rs
@@ -642,7 +642,7 @@ mod tests {
 
         assert_ron_snapshot!(
           compile(&project),
-          @r#"
+          @r##"
         GtlDist(
           files: [
             Generated(GtlDistFileGenerated(
@@ -655,11 +655,11 @@ mod tests {
             )),
             Generated(GtlDistFileGenerated(
               path: "examples/basic/dist/py/module/author.py",
-              source_code: "from __future__ import annotations\n\n\nfrom genotype import Model\n\n\nclass Author(Model):\n    name: str\n",
+              source_code: "# Do not edit manually! Code generated from ../../../src/author.type\n\nfrom __future__ import annotations\n\n\nfrom genotype import Model\n\n\nclass Author(Model):\n    name: str\n",
             )),
             Generated(GtlDistFileGenerated(
               path: "examples/basic/dist/py/module/book.py",
-              source_code: "from __future__ import annotations\n\n\nfrom .author import Author\nfrom genotype import Model\n\n\nclass Book(Model):\n    title: str\n    author: Author\n",
+              source_code: "# Do not edit manually! Code generated from ../../../src/book.type\n\nfrom __future__ import annotations\n\n\nfrom .author import Author\nfrom genotype import Model\n\n\nclass Book(Model):\n    title: str\n    author: Author\n",
             )),
             Generated(GtlDistFileGenerated(
               path: "examples/basic/dist/py/module/py.typed",
@@ -682,7 +682,7 @@ mod tests {
           ],
           diagnostics: [],
         )
-        "#
+        "##
         );
     }
 
@@ -693,7 +693,7 @@ mod tests {
 
         assert_ron_snapshot!(
           compile(&project),
-          @r#"
+          @r##"
         GtlDist(
           files: [
             Generated(GtlDistFileGenerated(
@@ -706,7 +706,7 @@ mod tests {
             )),
             Generated(GtlDistFileGenerated(
               path: "examples/nested/dist/py/module/inventory.py",
-              source_code: "from __future__ import annotations\n\n\nfrom .shop.goods.book import Book\nfrom genotype import Model\n\n\nclass Inventory(Model):\n    goods: list[Book]\n",
+              source_code: "# Do not edit manually! Code generated from ../../../src/inventory.type\n\nfrom __future__ import annotations\n\n\nfrom .shop.goods.book import Book\nfrom genotype import Model\n\n\nclass Inventory(Model):\n    goods: list[Book]\n",
             )),
             Generated(GtlDistFileGenerated(
               path: "examples/nested/dist/py/module/py.typed",
@@ -718,7 +718,7 @@ mod tests {
             )),
             Generated(GtlDistFileGenerated(
               path: "examples/nested/dist/py/module/shop/goods/book.py",
-              source_code: "from __future__ import annotations\n\n\nfrom genotype import Model\n\n\nclass Book(Model):\n    title: str\n",
+              source_code: "# Do not edit manually! Code generated from ../../../../../src/shop/goods/book.type\n\nfrom __future__ import annotations\n\n\nfrom genotype import Model\n\n\nclass Book(Model):\n    title: str\n",
             )),
             Generated(GtlDistFileGenerated(
               path: "examples/nested/dist/py/pyproject.toml",
@@ -737,7 +737,7 @@ mod tests {
           ],
           diagnostics: [],
         )
-        "#
+        "##
         );
     }
 
@@ -750,7 +750,7 @@ mod tests {
 
         assert_ron_snapshot!(
           compile(&project),
-          @r#"
+          @r##"
         GtlDist(
           files: [
             Generated(GtlDistFileGenerated(
@@ -763,7 +763,7 @@ mod tests {
             )),
             Generated(GtlDistFileGenerated(
               path: "examples/dependencies/dist/py/module/prompt.py",
-              source_code: "from __future__ import annotations\n\n\nfrom genotype_json import JsonAny\nfrom genotype import Model\n\n\nclass Prompt(Model):\n    content: str\n    output: JsonAny\n",
+              source_code: "# Do not edit manually! Code generated from ../../../src/prompt.type\n\nfrom __future__ import annotations\n\n\nfrom genotype_json import JsonAny\nfrom genotype import Model\n\n\nclass Prompt(Model):\n    content: str\n    output: JsonAny\n",
             )),
             Generated(GtlDistFileGenerated(
               path: "examples/dependencies/dist/py/module/py.typed",
@@ -782,7 +782,7 @@ mod tests {
           ],
           diagnostics: [],
         )
-        "#
+        "##
         );
     }
 
@@ -797,6 +797,8 @@ mod tests {
         assert_snapshot!(
             json.source_code,
             @r#"
+        # Do not edit manually! Code generated from ../../../src/json.type
+
         from __future__ import annotations
 
 
@@ -971,6 +973,30 @@ name = "module"
         [tool.hatch.build.targets.wheel]
         packages = ["module"]
         "#
+        );
+    }
+
+    #[test]
+    fn test_render_no_warning_comment() {
+        let backend = GtbSystem::new(&"./examples/basic".into()).unwrap();
+        let mut project = block_on(backend.create_project_and_load_all_modules(None)).unwrap();
+        project.config_mut().warning_comment = false;
+
+        let dist = compile(&project);
+        let module = get_dist_file(&dist, "module/author.py");
+
+        assert_snapshot!(
+            module.source_code,
+            @"
+        from __future__ import annotations
+
+
+        from genotype import Model
+
+
+        class Author(Model):
+            name: str
+        "
         );
     }
 

--- a/pkgs/crate-genotype-lang-rs-project/src/compiler.rs
+++ b/pkgs/crate-genotype-lang-rs-project/src/compiler.rs
@@ -729,6 +729,8 @@ mod tests {
         assert_snapshot!(
           dist.files[2].source_code(),
           @"
+        // Do not edit manually! Code generated from ../../../src/author.type
+
         use serde::{Deserialize, Serialize};
 
         #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -751,6 +753,8 @@ mod tests {
         assert_snapshot!(
           dist.files[3].source_code(),
           @"
+        // Do not edit manually! Code generated from ../../../src/book.type
+
         use super::author::Author;
         use serde::{Deserialize, Serialize};
 
@@ -837,6 +841,8 @@ mod tests {
         assert_snapshot!(
           dist.files[2].source_code(),
           @"
+        // Do not edit manually! Code generated from ../../../src/inventory.type
+
         use super::shop::goods::book::Book;
         use serde::{Deserialize, Serialize};
 
@@ -881,6 +887,8 @@ mod tests {
         assert_snapshot!(
           dist.files[4].source_code(),
           @"
+        // Do not edit manually! Code generated from ../../../../../src/shop/goods/book.type
+
         use serde::{Deserialize, Serialize};
 
         #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -936,6 +944,8 @@ mod tests {
         assert_snapshot!(
             node_file.source_code(),
             @r#"
+        // Do not edit manually! Code generated from ../../../src/node.type
+
         use serde::{Deserialize, Serialize};
 
         #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -963,6 +973,8 @@ mod tests {
         assert_snapshot!(
             tree_file.source_code(),
             @r#"
+        // Do not edit manually! Code generated from ../../../src/tree.type
+
         use serde::{Deserialize, Serialize};
 
         #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -1056,6 +1068,8 @@ mod tests {
         assert_snapshot!(
           dist.files[2].source_code(),
           @r#"
+        // Do not edit manually! Code generated from ../../../src/admin.type
+
         use serde::{Deserialize, Serialize};
         use litty::serde_literals;
         use crate::named::Name;
@@ -1119,6 +1133,8 @@ mod tests {
         assert_snapshot!(
           dist.files[4].source_code(),
           @"
+        // Do not edit manually! Code generated from ../../../src/named.type
+
         use litty::serde_literals;
         use serde::{Deserialize, Serialize};
 
@@ -1140,6 +1156,8 @@ mod tests {
         assert_snapshot!(
           dist.files[5].source_code(),
           @r#"
+        // Do not edit manually! Code generated from ../../../src/user.type
+
         use super::named::Name;
         use serde::{Deserialize, Serialize};
 
@@ -1231,6 +1249,8 @@ mod tests {
         assert_snapshot!(
           dist.files[3].source_code(),
           @"
+        // Do not edit manually! Code generated from ../../../src/prompt.type
+
         use genotype_json_types::JsonAny;
         use serde::{Deserialize, Serialize};
 
@@ -1292,6 +1312,28 @@ version = "0.3.0"
         [dependencies]
         serde = { version = "1", features = ["derive"] }
         "#
+        );
+    }
+
+    #[test]
+    fn test_render_no_warning_comment() {
+        let backend = GtbSystem::new(&"./examples/basic".into()).unwrap();
+        let mut project = block_on(backend.create_project_and_load_all_modules(None)).unwrap();
+        project.config_mut().warning_comment = false;
+
+        let dist = compile(&project);
+        let module = get_dist_file(&dist, "src/author.rs");
+
+        assert_snapshot!(
+            module.source_code,
+            @"
+        use serde::{Deserialize, Serialize};
+
+        #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+        pub struct Author {
+            pub name: String,
+        }
+        "
         );
     }
 
@@ -1378,6 +1420,18 @@ version = "0.3.0"
         dist.files
             .iter()
             .find(|file| file.path().as_str().contains("Cargo.toml"))
+            .unwrap()
+    }
+
+    fn get_dist_file<'a>(dist: &'a GtlDist, path_suffix: &str) -> &'a GtlDistFileGenerated {
+        dist.files
+            .iter()
+            .find_map(|file| match file {
+                GtlDistFile::Generated(file) if file.path.as_str().ends_with(path_suffix) => {
+                    Some(file)
+                }
+                _ => None,
+            })
             .unwrap()
     }
 }

--- a/pkgs/crate-genotype-lang-ts-project/src/compiler.rs
+++ b/pkgs/crate-genotype-lang-ts-project/src/compiler.rs
@@ -517,11 +517,11 @@ mod tests {
             )),
             Generated(GtlDistFileGenerated(
               path: "examples/basic/dist/ts/src/author.ts",
-              source_code: "export interface Author {\n  name: string;\n}\n",
+              source_code: "// Do not edit manually! Code generated from ../../../src/author.type\n\nexport interface Author {\n  name: string;\n}\n",
             )),
             Generated(GtlDistFileGenerated(
               path: "examples/basic/dist/ts/src/book.ts",
-              source_code: "import { Author } from \"./author.js\";\n\nexport interface Book {\n  title: string;\n  author: Author;\n}\n",
+              source_code: "// Do not edit manually! Code generated from ../../../src/book.type\n\nimport { Author } from \"./author.js\";\n\nexport interface Book {\n  title: string;\n  author: Author;\n}\n",
             )),
             Generated(GtlDistFileGenerated(
               path: "examples/basic/dist/ts/src/index.ts",
@@ -562,13 +562,15 @@ mod tests {
         assert_snapshot!(
           get_dist_file(&dist, "src/book.ts").source_code,
           @r#"
-      import { Author } from "./author.ts";
+        // Do not edit manually! Code generated from ../../../src/book.type
 
-      export interface Book {
-        title: string;
-        author: Author;
-      }
-      "#
+        import { Author } from "./author.ts";
+
+        export interface Book {
+          title: string;
+          author: Author;
+        }
+        "#
         );
         assert_snapshot!(
           get_dist_file(&dist, "src/index.ts").source_code,
@@ -617,7 +619,7 @@ mod tests {
             )),
             Generated(GtlDistFileGenerated(
               path: "examples/dependencies/dist/ts/src/prompt.ts",
-              source_code: "import { JsonAny } from \"@genotype/json\";\n\nexport interface Prompt {\n  content: string;\n  output: JsonAny;\n}\n",
+              source_code: "// Do not edit manually! Code generated from ../../../src/prompt.type\n\nimport { JsonAny } from \"@genotype/json\";\n\nexport interface Prompt {\n  content: string;\n  output: JsonAny;\n}\n",
             )),
           ],
           modules: [
@@ -715,6 +717,8 @@ mod tests {
         assert_snapshot!(
             author_file.source_code,
             @r#"
+        // Do not edit manually! Code generated from ../../../src/author.type
+
         import { z } from "zod";
 
         export const Author = z.object({
@@ -737,17 +741,21 @@ mod tests {
         let author_file = get_dist_file(&dist, "src/author.ts");
         assert_snapshot!(
             author_file.source_code,
-            @r#"
+            @"
+        // Do not edit manually! Code generated from ../../../src/author.type
+
         export type Author = {
           name: string;
         };
-        "#
+        "
         );
 
         let book_file = get_dist_file(&dist, "src/book.ts");
         assert_snapshot!(
             book_file.source_code,
             @r#"
+        // Do not edit manually! Code generated from ../../../src/book.type
+
         import { Author } from "./author.js";
 
         export type Book = {
@@ -755,6 +763,25 @@ mod tests {
           author: Author;
         };
         "#
+        );
+    }
+
+    #[test]
+    fn test_render_no_warning_comment() {
+        let backend = GtbSystem::new(&"./examples/basic".into()).unwrap();
+        let mut project = block_on(backend.create_project_and_load_all_modules(None)).unwrap();
+        project.config_mut().warning_comment = false;
+
+        let dist = compile(&project);
+        let module = get_dist_file(&dist, "src/author.ts");
+
+        assert_snapshot!(
+            module.source_code,
+            @"
+        export interface Author {
+          name: string;
+        }
+        "
         );
     }
 
@@ -855,7 +882,7 @@ mod tests {
             )),
             Generated(GtlDistFileGenerated(
               path: "../../examples/04-tests/generics/dist/ts-interface/ts/src/generics.ts",
-              source_code: "export type Response<Payload> = ResponseSuccess<Payload> | ResponseFailure;\n\nexport interface ResponseSuccess<Payload> {\n  status: \"success\";\n  value: Payload;\n}\n\nexport interface ResponseFailure {\n  status: \"failure\";\n  error: string;\n}\n\nexport type ResponseString = Response<string>;\n\nexport type ResponsePair = Response<import(\"./pair.js\").Pair<string, number>>;\n",
+              source_code: "// Do not edit manually! Code generated from ../../../../src/generics.type\n\nexport type Response<Payload> = ResponseSuccess<Payload> | ResponseFailure;\n\nexport interface ResponseSuccess<Payload> {\n  status: \"success\";\n  value: Payload;\n}\n\nexport interface ResponseFailure {\n  status: \"failure\";\n  error: string;\n}\n\nexport type ResponseString = Response<string>;\n\nexport type ResponsePair = Response<import(\"./pair.js\").Pair<string, number>>;\n",
             )),
             Generated(GtlDistFileGenerated(
               path: "../../examples/04-tests/generics/dist/ts-interface/ts/src/index.ts",
@@ -863,7 +890,7 @@ mod tests {
             )),
             Generated(GtlDistFileGenerated(
               path: "../../examples/04-tests/generics/dist/ts-interface/ts/src/pair.ts",
-              source_code: "export interface Pair<Left, Right> {\n  left: Left;\n  right: Right;\n}\n",
+              source_code: "// Do not edit manually! Code generated from ../../../../src/pair.type\n\nexport interface Pair<Left, Right> {\n  left: Left;\n  right: Right;\n}\n",
             )),
           ],
           modules: [

--- a/pkgs/crate-genotype-project-core/src/lang_config/mod.rs
+++ b/pkgs/crate-genotype-project-core/src/lang_config/mod.rs
@@ -48,4 +48,12 @@ pub trait GtpLangConfig {
     ) -> Vec<GtDiagnostic> {
         vec![]
     }
+
+    fn comment_prefix(&self) -> &'static str {
+        "//"
+    }
+
+    fn comment_line(&self, content: &str) -> String {
+        format!("{prefix} {content}", prefix = self.comment_prefix(),)
+    }
 }

--- a/pkgs/crate-genotype-project/src/config/mod.rs
+++ b/pkgs/crate-genotype-project/src/config/mod.rs
@@ -14,6 +14,10 @@ const fn default_package() -> bool {
     true
 }
 
+const fn default_warning_comment() -> bool {
+    true
+}
+
 #[derive(Debug, Serialize, Deserialize, PartialEq, Clone)]
 pub struct GtpConfig {
     /// Project name.
@@ -38,6 +42,8 @@ pub struct GtpConfig {
     /// Global formatters to run after all selected targets are compiled.
     #[serde(default)]
     pub formatters: Vec<GtpFormatter>,
+    #[serde(default = "default_warning_comment")]
+    pub warning_comment: bool,
     /// TypeScript config.
     #[serde(default, alias = "typescript")]
     pub ts: TsConfig,
@@ -66,6 +72,7 @@ impl Default for GtpConfig {
             py: Default::default(),
             rs: Default::default(),
             source_toml_str: String::new(),
+            warning_comment: true,
         }
     }
 }


### PR DESCRIPTION
Add warning comment to generated target files. It can be disabled via `warning_comment`.

See #129

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Generated source files now include a “Do not edit manually” header by default, pointing to their originating source.
  * Added a `warning_comment` configuration option to enable or disable these headers.
  * Headers use language-appropriate comment syntax.
* **Bug Fixes**
  * Rendering errors are now surfaced properly instead of being ignored.
* **Tests**
  * Updated generation snapshots and added coverage for disabling the warning header.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->