### PR TITLE
Generate unique names for array & tuple element unions

### DIFF
--- a/examples/04-tests/errors-build/map-key-inline-branded/genotype.toml
+++ b/examples/04-tests/errors-build/map-key-inline-branded/genotype.toml
@@ -1,0 +1,14 @@
+name = "genotype-test-map-key-inline-branded"
+
+[ts]
+enabled = true
+
+[rs]
+enabled = true
+
+[rs.manifest.package]
+edition = "2024"
+
+[py]
+enabled = true
+manager = "uv"

--- a/examples/04-tests/errors-build/map-key-inline-branded/output.snap
+++ b/examples/04-tests/errors-build/map-key-inline-branded/output.snap
@@ -1,0 +1,33 @@
+
+[1m[31mError[39m[0m: Failed to parse module `src/map.type`.
+
+[31m×[0m Syntax error: expected name or primitive_numeric
+   ╭─[[36;1;4msrc/map.type:1:22[0m]
+ [2m1[0m │ [38;2;79;91;102mInlineBrandedMap: { [[38;2;180;142;173m@string[38;2;79;91;102m]: [38;2;180;142;173mstring[38;2;79;91;102m }[0m
+   · [35;1m                     ▲[0m
+   ·                      [35;1m╰── [35;1mHere[0m[0m
+   ╰────
+
+[1m[31mError[39m[0m: Failed to convert `dist/ts/src/map.ts` from `src/map.type`.
+
+[1m[33mWarning[39m[0m: Some of the modules failed to render.
+
+- Failed to convert `dist/ts/src/map.ts` from `src/map.type`
+
+[1m[33mWarning[39m[0m: Barrel file `dist/ts/src/index.ts` rendered, but it excludes 1 module that failed to render.
+
+[1m[31mError[39m[0m: Failed to convert `dist/py/module/map.py` from `src/map.type`.
+
+[1m[33mWarning[39m[0m: Some of the modules failed to render.
+
+- Failed to convert `dist/py/module/map.py` from `src/map.type`
+
+[1m[33mWarning[39m[0m: Init file `dist/py/module/__init__.py` rendered, but it excludes 1 module that failed to render.
+
+[1m[31mError[39m[0m: Failed to convert `dist/rs/src/map.rs` from `src/map.type`.
+
+[1m[33mWarning[39m[0m: Some of the modules failed to render.
+
+- Failed to convert `dist/rs/src/map.rs` from `src/map.type`
+
+[1m[33mWarning[39m[0m: Project generated to `dist` with 4 errors.

--- a/examples/04-tests/errors-build/map-key-inline-branded/src/map.type
+++ b/examples/04-tests/errors-build/map-key-inline-branded/src/map.type
@@ -1,0 +1,1 @@
+InlineBrandedMap: { [@string]: string }

--- a/pkgs/crate-genotype-lang-rs-project/src/module/mod.rs
+++ b/pkgs/crate-genotype-lang-rs-project/src/module/mod.rs
@@ -118,7 +118,12 @@ impl GtlProjectModule for RsProjectModule {
 
         let project_resolve = RsProjectModuleResolve::new(module_resolve);
 
-        let module = RsModule::convert(&parse.module, &convert_resolve, lang_config)?;
+        let module = RsModule::convert(
+            &parse.module,
+            &parse.resolve.exports,
+            &convert_resolve,
+            lang_config,
+        )?;
 
         Ok(RsProjectModule {
             module,

--- a/pkgs/crate-genotype-lang-rs-tree/src/alias/convert.rs
+++ b/pkgs/crate-genotype-lang-rs-tree/src/alias/convert.rs
@@ -14,7 +14,6 @@ impl RsConvert<RsDefinition> for GtAlias {
             .iter()
             .map(|generic| generic.identifier.convert(context))
             .collect::<RsConvertResult<Vec<_>>>()?;
-        context.push_defined(&name);
         context.enter_generics_scope(generics.clone());
         context.enter_parent(RsContextParent::Alias(name.clone()));
 

--- a/pkgs/crate-genotype-lang-rs-tree/src/convert/context/mod.rs
+++ b/pkgs/crate-genotype-lang-rs-tree/src/convert/context/mod.rs
@@ -19,6 +19,10 @@ pub struct RsConvertContext {
     config: RsConfigLang,
     imports: Vec<RsUse>,
     definitions: Vec<RsDefinition>,
+    /// List of reserved identifiers that is used to generate unique synthetic identifiers, i.e.,
+    /// for inline stype aliases. It is populated from module exports and then updated when new
+    /// identifiers are generated.
+    reserved: IndexSet<RsIdentifier>,
     defined: Vec<RsIdentifier>,
     hoisting: bool,
     hoist_defined: Vec<RsIdentifier>,
@@ -70,6 +74,7 @@ impl RsConvertContext {
             config,
             imports: vec![],
             definitions: vec![],
+            reserved: Default::default(),
             defined: vec![],
             hoisting: false,
             hoist_defined: vec![],
@@ -172,6 +177,10 @@ impl RsConvertContext {
         } else {
             self.defined.push(identifier.clone());
         }
+    }
+
+    pub fn reserve(&mut self, identifier: RsIdentifier) {
+        self.reserved.insert(identifier);
     }
 
     pub fn push_definition(&mut self, definition: RsDefinition) {

--- a/pkgs/crate-genotype-lang-rs-tree/src/convert/context/mod.rs
+++ b/pkgs/crate-genotype-lang-rs-tree/src/convert/context/mod.rs
@@ -20,8 +20,8 @@ pub struct RsConvertContext {
     imports: Vec<RsUse>,
     definitions: Vec<RsDefinition>,
     /// List of reserved identifiers that is used to generate unique synthetic identifiers, i.e.,
-    /// for inline stype aliases. It is populated from module exports and then updated when new
-    /// identifiers are generated.
+    /// for inline type aliases. It is populated from module exports and used together with
+    /// [RsConvertContext::defined] list to ensure that generated identifiers are unique.
     reserved: IndexSet<RsIdentifier>,
     defined: Vec<RsIdentifier>,
     hoisting: bool,

--- a/pkgs/crate-genotype-lang-rs-tree/src/convert/context/naming.rs
+++ b/pkgs/crate-genotype-lang-rs-tree/src/convert/context/naming.rs
@@ -10,6 +10,8 @@ pub enum RsContextParent {
     /// Anonymous parent that prevents children from taking the alias name, when they for example
     /// are part of a tuple.
     Anonymous,
+    VecElement,
+    TupleElement(usize),
     Definition(RsIdentifier),
     Field(RsFieldName),
     EnumVariant(RsIdentifier),
@@ -23,6 +25,8 @@ impl RsContextParent {
             Self::Definition(identifier) => identifier.0.clone(),
             Self::Field(key) => key.0.clone(),
             Self::EnumVariant(identifier) => identifier.0.clone(),
+            Self::VecElement => "Element".into(),
+            Self::TupleElement(index) => format!("Element{index}").into(),
             Self::Anonymous => panic!("Cannot get name of anonymous parent"),
             Self::Hoist => panic!("Cannot get name of hoist parent"),
         }
@@ -46,7 +50,7 @@ impl RsConvertContext {
         self.parents.pop().expect("Expected parent to exist");
     }
 
-    pub fn name_child(&self, name: Option<RsConvertNameSegment>) -> RsIdentifier {
+    pub fn name_child(&mut self, name: Option<RsConvertNameSegment>) -> RsIdentifier {
         let mut segments = vec![];
         for parent in self.parents.iter().rev() {
             match parent {
@@ -67,12 +71,28 @@ impl RsConvertContext {
         }
 
         let solo = segments.len() == 1;
-        segments
+        let name = segments
             .iter()
             .map(|name| name.render(solo))
             .collect::<Vec<_>>()
             .join("")
-            .into()
+            .into();
+
+        self.claim_generated_name(name)
+    }
+
+    fn claim_generated_name(&mut self, name: RsIdentifier) -> RsIdentifier {
+        let mut candidate = name.clone();
+        let mut index = 2;
+        while self.reserved.contains(&candidate)
+            || self.defined.contains(&candidate)
+            || self.hoist_defined.contains(&candidate)
+        {
+            candidate = format!("{}{index}", name.0).into();
+            index += 1;
+        }
+        self.push_defined(&candidate);
+        candidate
     }
 
     /// Tries claiming the alias from the parent, i.e. when naming literals:
@@ -176,6 +196,17 @@ mod tests {
     }
 
     #[test]
+    fn test_reserved_name_wins_over_generated_name() {
+        let mut context = RsConvertContext::empty("module".into());
+        context.reserve("ValuesElement".into());
+        context.enter_parent(RsContextParent::Alias("Values".into()));
+        context.enter_parent(RsContextParent::VecElement);
+
+        assert_eq!(context.name_child(None), "ValuesElement2".into());
+        assert_eq!(context.defined, vec!["ValuesElement2".into()]);
+    }
+
+    #[test]
     fn test_name_hoisted_child() {
         let mut context = RsConvertContext::empty("module".into());
         context.enter_parent(RsContextParent::Definition("Person".into()));
@@ -206,7 +237,7 @@ mod tests {
 
     #[test]
     fn test_name_solo_literal_number_child() {
-        let context = RsConvertContext::empty("module".into());
+        let mut context = RsConvertContext::empty("module".into());
         assert_eq!(
             context.name_child(Some(
                 GtLiteral {
@@ -242,7 +273,7 @@ mod tests {
 
     #[test]
     fn test_name_solo_invalid_literal_child() {
-        let context = RsConvertContext::empty("module".into());
+        let mut context = RsConvertContext::empty("module".into());
         assert_eq!(
             context.name_child(Some(
                 GtLiteral {

--- a/pkgs/crate-genotype-lang-rs-tree/src/module/convert.rs
+++ b/pkgs/crate-genotype-lang-rs-tree/src/module/convert.rs
@@ -3,10 +3,11 @@ use crate::prelude::internal::*;
 impl RsModule {
     pub fn convert(
         module: &GtModule,
+        exports: &[GtIdentifier],
         resolve: &RsConvertResolve,
         config: &RsConfig,
     ) -> Result<Self, Box<dyn GtlError>> {
-        match Self::convert_inner(module, resolve, config) {
+        match Self::convert_inner(module, exports, resolve, config) {
             Ok(module) => Ok(module),
             Err(err) => Err(Box::new(err)),
         }
@@ -14,6 +15,7 @@ impl RsModule {
 
     fn convert_inner(
         module: &GtModule,
+        exports: &[GtIdentifier],
         resolve: &RsConvertResolve,
         config: &RsConfig,
     ) -> RsConvertResult<Self> {
@@ -24,6 +26,11 @@ impl RsModule {
             config.lang.clone(),
             config.common.dependencies.clone(),
         );
+
+        for export in exports {
+            let name = export.convert(&mut context)?;
+            context.reserve(name);
+        }
 
         let doc = if let Some(doc) = &module.doc {
             let mut doc = doc.convert(&mut context)?;
@@ -62,6 +69,249 @@ impl RsModule {
 mod tests {
     use super::*;
     use genotype_test::*;
+
+    #[test]
+    fn test_convert_array_union() {
+        assert_ron_snapshot!(
+            convert_aliases(vec![Gt::alias(
+                "Values",
+                Gt::array(Gt::union(vec_into![
+                    Gt::primitive_string(),
+                    Gt::primitive_i64(),
+                    Gt::primitive_boolean(),
+                ])),
+            )]),
+            @r#"
+        RsModule(
+          id: GtModuleId("module"),
+          doc: None,
+          imports: [
+            RsUse(
+              dependency: Serde,
+              reference: Named([
+                Name(RsIdentifier("Deserialize")),
+                Name(RsIdentifier("Serialize")),
+              ]),
+            ),
+          ],
+          definitions: [
+            Alias(RsAlias(
+              id: GtDefinitionId(GtModuleId("module"), "Values"),
+              doc: None,
+              name: RsIdentifier("Values"),
+              generics: [],
+              descriptor: Vec(RsVec(
+                descriptor: Reference(RsReference(
+                  id: GtReferenceId(GtModuleId("module"), GtSpan(0, 0)),
+                  identifier: RsIdentifier("ValuesElement"),
+                  arguments: [],
+                  definition_id: GtDefinitionId(GtModuleId("module"), "ValuesElement"),
+                )),
+              )),
+            )),
+            Enum(RsEnum(
+              id: GtDefinitionId(GtModuleId("module"), "ValuesElement"),
+              doc: None,
+              attributes: [
+                RsAttribute("derive(Clone, Debug, Deserialize, PartialEq, Serialize)"),
+                RsAttribute("serde(untagged)"),
+              ],
+              name: RsIdentifier("ValuesElement"),
+              generics: [],
+              variants: [
+                RsEnumVariant(
+                  doc: None,
+                  attributes: [],
+                  name: RsIdentifier("String"),
+                  descriptor: Some(Descriptor(Primitive(String))),
+                ),
+                RsEnumVariant(
+                  doc: None,
+                  attributes: [],
+                  name: RsIdentifier("Int"),
+                  descriptor: Some(Descriptor(Primitive(Int64))),
+                ),
+                RsEnumVariant(
+                  doc: None,
+                  attributes: [],
+                  name: RsIdentifier("Boolean"),
+                  descriptor: Some(Descriptor(Primitive(Boolean))),
+                ),
+              ],
+            )),
+          ],
+        )
+        "#,
+        );
+    }
+
+    #[test]
+    fn test_explicit_export_wins_over_generated_name() {
+        let module = RsModule::convert(
+            &GtModule {
+                id: "module".into(),
+                doc: None,
+                imports: vec![],
+                aliases: vec![Gt::alias(
+                    "Values",
+                    Gt::array(Gt::union(vec_into![
+                        Gt::primitive_string(),
+                        Gt::primitive_i64(),
+                    ])),
+                )],
+            },
+            &[
+                GtIdentifier::new((0, 0).into(), "Values".into()),
+                GtIdentifier::new((0, 0).into(), "ValuesElement".into()),
+            ],
+            &Default::default(),
+            &Default::default(),
+        )
+        .unwrap();
+
+        assert_eq!(
+            module
+                .definitions
+                .iter()
+                .map(|definition| definition.name().0.as_ref())
+                .collect::<Vec<_>>(),
+            ["Values", "ValuesElement2"]
+        );
+    }
+
+    #[test]
+    fn test_convert_tuple_unions() {
+        assert_ron_snapshot!(
+            convert_aliases(vec![Gt::alias(
+                "Point",
+                Gt::tuple(vec_into![
+                    Gt::union(vec_into![Gt::primitive_f64(), Gt::primitive_i64()]),
+                    Gt::union(vec_into![Gt::primitive_f64(), Gt::primitive_i64()]),
+                ]),
+            )]),
+            @r#"
+        RsModule(
+          id: GtModuleId("module"),
+          doc: None,
+          imports: [
+            RsUse(
+              dependency: Serde,
+              reference: Named([
+                Name(RsIdentifier("Deserialize")),
+                Name(RsIdentifier("Serialize")),
+              ]),
+            ),
+          ],
+          definitions: [
+            Alias(RsAlias(
+              id: GtDefinitionId(GtModuleId("module"), "Point"),
+              doc: None,
+              name: RsIdentifier("Point"),
+              generics: [],
+              descriptor: Tuple(RsTuple(
+                descriptors: [
+                  Reference(RsReference(
+                    id: GtReferenceId(GtModuleId("module"), GtSpan(0, 0)),
+                    identifier: RsIdentifier("PointElement0"),
+                    arguments: [],
+                    definition_id: GtDefinitionId(GtModuleId("module"), "PointElement0"),
+                  )),
+                  Reference(RsReference(
+                    id: GtReferenceId(GtModuleId("module"), GtSpan(0, 0)),
+                    identifier: RsIdentifier("PointElement1"),
+                    arguments: [],
+                    definition_id: GtDefinitionId(GtModuleId("module"), "PointElement1"),
+                  )),
+                ],
+              )),
+            )),
+            Enum(RsEnum(
+              id: GtDefinitionId(GtModuleId("module"), "PointElement0"),
+              doc: None,
+              attributes: [
+                RsAttribute("derive(Clone, Debug, Deserialize, PartialEq, Serialize)"),
+                RsAttribute("serde(untagged)"),
+              ],
+              name: RsIdentifier("PointElement0"),
+              generics: [],
+              variants: [
+                RsEnumVariant(
+                  doc: None,
+                  attributes: [],
+                  name: RsIdentifier("Float"),
+                  descriptor: Some(Descriptor(Primitive(Float64))),
+                ),
+                RsEnumVariant(
+                  doc: None,
+                  attributes: [],
+                  name: RsIdentifier("Int"),
+                  descriptor: Some(Descriptor(Primitive(Int64))),
+                ),
+              ],
+            )),
+            Enum(RsEnum(
+              id: GtDefinitionId(GtModuleId("module"), "PointElement1"),
+              doc: None,
+              attributes: [
+                RsAttribute("derive(Clone, Debug, Deserialize, PartialEq, Serialize)"),
+                RsAttribute("serde(untagged)"),
+              ],
+              name: RsIdentifier("PointElement1"),
+              generics: [],
+              variants: [
+                RsEnumVariant(
+                  doc: None,
+                  attributes: [],
+                  name: RsIdentifier("Float"),
+                  descriptor: Some(Descriptor(Primitive(Float64))),
+                ),
+                RsEnumVariant(
+                  doc: None,
+                  attributes: [],
+                  name: RsIdentifier("Int"),
+                  descriptor: Some(Descriptor(Primitive(Int64))),
+                ),
+              ],
+            )),
+          ],
+        )
+        "#,
+        );
+    }
+
+    #[test]
+    fn test_explicit_export_wins_over_generated_tuple_name() {
+        let module = RsModule::convert(
+            &GtModule {
+                id: "module".into(),
+                doc: None,
+                imports: vec![],
+                aliases: vec![Gt::alias(
+                    "Point",
+                    Gt::tuple(vec_into![
+                        Gt::union(vec_into![Gt::primitive_f64(), Gt::primitive_i64()]),
+                        Gt::union(vec_into![Gt::primitive_f64(), Gt::primitive_i64()]),
+                    ]),
+                )],
+            },
+            &[
+                GtIdentifier::new((0, 0).into(), "Point".into()),
+                GtIdentifier::new((0, 0).into(), "PointElement0".into()),
+            ],
+            &Default::default(),
+            &Default::default(),
+        )
+        .unwrap();
+
+        assert_eq!(
+            module
+                .definitions
+                .iter()
+                .map(|definition| definition.name().0.as_ref())
+                .collect::<Vec<_>>(),
+            ["Point", "PointElement02", "PointElement1"]
+        );
+    }
 
     #[test]
     fn test_convert() {
@@ -223,6 +473,7 @@ mod tests {
                         },
                     ],
                 },
+                &[],
                 &resolve,
                 &Default::default(),
             )
@@ -352,6 +603,7 @@ mod tests {
                     imports: vec![],
                     aliases: vec![],
                 },
+                &[],
                 &Default::default(),
                 &Default::default(),
             )
@@ -365,5 +617,24 @@ mod tests {
         )
         "#
         );
+    }
+
+    fn convert_aliases(aliases: Vec<GtAlias>) -> RsModule {
+        let exports = aliases
+            .iter()
+            .map(|alias| alias.name.clone())
+            .collect::<Vec<_>>();
+        RsModule::convert(
+            &GtModule {
+                id: "module".into(),
+                doc: None,
+                imports: vec![],
+                aliases,
+            },
+            &exports,
+            &Default::default(),
+            &Default::default(),
+        )
+        .unwrap()
     }
 }

--- a/pkgs/crate-genotype-lang-rs-tree/src/tuple/convert.rs
+++ b/pkgs/crate-genotype-lang-rs-tree/src/tuple/convert.rs
@@ -3,16 +3,20 @@ use crate::prelude::internal::*;
 impl RsConvert<RsTuple> for GtTuple {
     fn convert(&self, context: &mut RsConvertContext) -> RsConvertResult<RsTuple> {
         context.drop_definition_id();
-        context.enter_parent(RsContextParent::Anonymous);
 
         let descriptors = self
             .descriptors
             .iter()
-            .map(|descriptor| descriptor.convert(context))
+            .enumerate()
+            .map(|(index, descriptor)| {
+                context.enter_parent(RsContextParent::TupleElement(index));
+                let descriptor = descriptor.convert(context);
+                context.exit_parent();
+                descriptor
+            })
             .collect::<RsConvertResult<Vec<_>>>()?;
         let tuple = RsTuple { descriptors };
 
-        context.exit_parent();
         Ok(tuple)
     }
 }

--- a/pkgs/crate-genotype-lang-rs-tree/src/vec/convert.rs
+++ b/pkgs/crate-genotype-lang-rs-tree/src/vec/convert.rs
@@ -2,7 +2,9 @@ use crate::prelude::internal::*;
 
 impl RsConvert<RsVec> for GtArray {
     fn convert(&self, context: &mut RsConvertContext) -> RsConvertResult<RsVec> {
+        context.enter_parent(RsContextParent::VecElement);
         let descriptor = self.descriptor.convert(context)?;
+        context.exit_parent();
         Ok(RsVec { descriptor })
     }
 }

--- a/pkgs/crate-genotype-parser/src/parser/mod.rs
+++ b/pkgs/crate-genotype-parser/src/parser/mod.rs
@@ -96,6 +96,11 @@ mod tests {
     }
 
     #[test]
+    fn rejects_inline_branded_record_key() {
+        assert!(parse_gt_code("Record: { [@string]: string }").is_err());
+    }
+
+    #[test]
     fn test_number_sizes() {
         parse_file("../../examples/02-syntax/17-number_sizes.type");
     }


### PR DESCRIPTION
See:

- #153
- #154
- #155


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved generated Rust naming to prevent collisions with exported, reserved, or existing names.
  * Added clearer naming for array and tuple elements in generated Rust code.
  * Preserved explicit exported names during Rust code generation.
  * Inline branded map keys now correctly produce a parse error when unsupported.

* **Tests**
  * Added coverage for naming collisions, array and tuple unions, and invalid inline branded map keys.
  * Added multi-language test configuration for TypeScript, Rust, and Python.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->